### PR TITLE
Bugfix/active navigation highlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out
 feed.xml
 .vscode
 built
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -5252,8 +5252,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "optional": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pify": {
       "version": "4.0.1",

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -30,7 +30,7 @@ export default function Layout({ children, location }: Props) {
         className={`text-foreground-primary px-8 bg-background-primary duration-200 border-t-0 border-red-500`}
       >
         <div className="flex flex-col min-h-screen ml-auto mr-auto w-full md:w-4/5 lg:max-w-3xl">
-          <header className="mt-6 flex flex-wrap fade-out">
+          <header className="mt-6 md:mb-3 flex flex-wrap fade-out">
             <h1 className="order-1 font-extrabold tracking-tight text-2xl mr-4 md:text-3xl">
               <Link href="/">
                 <a className={router.pathname === "/" ? "border-b-4" : ""}>
@@ -39,12 +39,12 @@ export default function Layout({ children, location }: Props) {
                 </a>
               </Link>
             </h1>
-            <nav className="order-3 md:order-2 w-full md:w-auto text-sm md:text-xl font-normal align-middle justify-center self-center">
+            <nav className="order-3 lg:order-2 w-full lg:w-auto mt-3 lg:mt-0 lg:pl-3 text-sm md:text-xl font-normal align-middle justify-center self-center">
               {navLinks.map((navLink) => (
                 <Link href={navLink.url} key={navLink.label}>
                   <a
                     className={
-                      "block md:inline -ml-2 mb-1 md:m-0 pl-1 p-0 md:px-3 md:py-2 border-l-4 md:border-l-0 border-transparent font-semibold hover:text-red-500 " +
+                      "block md:inline -ml-2 mb-1 md:m-0 pl-1 p-0 md:pl-0 md:py-2 md:mr-6 border-l-4 md:border-l-0 border-transparent font-semibold hover:text-red-500 " +
                       `${
                         router.pathname.includes(navLink.url)
                           ? "md:border-b-4 border-red-500"
@@ -61,7 +61,7 @@ export default function Layout({ children, location }: Props) {
               onClick={() => darkMode.toggle()}
               id="toggleTheme"
               aria-pressed={darkMode.value}
-              className="order-2 md:order-3 ml-auto p-2 inline-block transform hover:-rotate-180 duration-300 ease-in-out "
+              className="order-2 lg:order-3 ml-auto p-2 inline-block transform hover:-rotate-180 duration-300 ease-in-out "
             >
               {darkMode.value ? "☀️" : "😎"}
             </button>


### PR DESCRIPTION
Original intention was to fix the header links so that the active page highlight matches the text width.

Before:
![Screenshot 2020-08-18 at 21 24 37](https://user-images.githubusercontent.com/1064686/90562365-f4b57500-e199-11ea-9de3-1b04ca2cd23b.png)

After:
![Screenshot 2020-08-18 at 21 24 53](https://user-images.githubusercontent.com/1064686/90562392-fda64680-e199-11ea-9453-057057faa50d.png)

Then I noticed that the header responsive at 768 (md) needs to break slightly earlier so I moved it to 1024 (lg) and neatened up some spacings.

Before:
![Screenshot 2020-08-18 at 21 24 14](https://user-images.githubusercontent.com/1064686/90562465-21698c80-e19a-11ea-870f-96663c572c2c.png)
![Screenshot 2020-08-18 at 21 24 26](https://user-images.githubusercontent.com/1064686/90562513-31816c00-e19a-11ea-8b88-92aac81115fa.png)

After:
![Screenshot 2020-08-18 at 21 25 05](https://user-images.githubusercontent.com/1064686/90562488-29c1c780-e19a-11ea-9a3c-0ee112077319.png)
