### PR TITLE
Fixed Youtube Channel overflow issue on About page.

### DIFF
--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -38,7 +38,9 @@
     @apply mt-6;
   }
 
-  a {
+  a,
+  p > a,
+  ul > li > a {
     @apply text-href-base underline;
   }
 

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -81,10 +81,9 @@ export default function AboutRoute() {
 
           <h3>Our YouTube Channel</h3>
           <p>
-            Recently we've been investing heavily into our YouTube Channel
-            &mdash;
+            Recently we've been investing heavily into our&nbsp;
             <a href="https://www.youtube.com/c/NorfolkDevelopers/">
-              https://www.youtube.com/c/NorfolkDevelopers/
+              YouTube Channel
             </a>
             .&nbsp; We record or stream most of our events and welcome you to
             subscribe and turn on notifications so you get those alerts when we


### PR DESCRIPTION
Changed link to wrap Youtube Channel text and also changed link styling in typography.css as the styles were not being picked up by the link.