### PR TITLE
Adds tailwind purge configuration

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,4 +24,10 @@ module.exports = {
   },
   variants: {},
   plugins: [],
+  purge: [
+    './src/components/*.tsx',
+    './src/components/**/*.tsx',
+    './src/pages/*.tsx',
+    './src/pages/**/*.tsx',
+  ],
 };


### PR DESCRIPTION
Spotted a warning during build about undeclared purge directories. I've added components and pages for now.

I think that's enough, but we'll need to keep an eye on it of course. Not sure if both declarations are requred, e.g: 

```json
'./src/components/*.tsx',
'./src/components/**/*.tsx',
```