### PR TITLE
Update presentation of job meta information

### DIFF
--- a/src/DataTypes.ts
+++ b/src/DataTypes.ts
@@ -17,7 +17,7 @@ export type JobData = BaseData & {
   salary: string;
   expiryDate: string;
   company?: string;
-  location?: string;
+  location: string;
   seniority?: string;
   apply?: string;
 };

--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
-import TagList from "src/components/TagList";
+import { JobData } from "src/DataTypes";
 import JobDetails from "src/components/JobDetails";
-import { JobData } from "../DataTypes";
+import JobSubtitle from "src/components/JobSubtitle";
 
 type Props = {
   job: JobData;
@@ -14,7 +14,8 @@ export default function JobCard({ job }: Props) {
         <Link href={job.path || ""}>
           <a>
             <h2 className="text-2xl text-foreground-primary font-bold tracking-tight hover:text-red-500">
-              {job.title}
+              {job.title}&nbsp;
+              <JobSubtitle job={job} />
             </h2>
           </a>
         </Link>

--- a/src/components/JobDetails.tsx
+++ b/src/components/JobDetails.tsx
@@ -21,10 +21,6 @@ export default function JobDetails({ job }: Props) {
         <span className="mr-2" role="img" aria-label="Job Role">💼</span>
         {job.role}
       </li>
-      <li className="mb-2 md:mb-0 md:mr-2">
-        <span className="mr-2" role="img" aria-label="Salary">👛</span>
-        {job.salary}
-      </li>
     </ol>
   );
 }

--- a/src/components/JobSubtitle.tsx
+++ b/src/components/JobSubtitle.tsx
@@ -5,12 +5,11 @@ type Props = {
 };
 
 export default function JobSubtitle({ job }: Props) {
-    const hasSubtitle = job.location || job.salary || job.seniority;
-    return (hasSubtitle ? <span className="text-foreground-secondary">
+    return <span className="text-foreground-secondary">
         (
-            {job.location || ''}
+            {job.location}
             {job.salary ? ` / ${job.salary}` : ''}
             {job.seniority ? ` / ${job.seniority}` : ''}
         )
-    </span> : null)
+    </span>
 }

--- a/src/components/JobSubtitle.tsx
+++ b/src/components/JobSubtitle.tsx
@@ -1,0 +1,16 @@
+import { JobData } from "src/DataTypes";
+
+type Props = {
+    job: JobData
+};
+
+export default function JobSubtitle({ job }: Props) {
+    const hasSubtitle = job.location || job.salary || job.seniority;
+    return (hasSubtitle ? <span className="text-foreground-secondary">
+        (
+            {job.location || ''}
+            {job.salary ? ` / ${job.salary}` : ''}
+            {job.seniority ? ` / ${job.seniority}` : ''}
+        )
+    </span> : null)
+}

--- a/src/components/layout/JobTemplate.tsx
+++ b/src/components/layout/JobTemplate.tsx
@@ -1,14 +1,9 @@
 import Layout from "./Layout";
-import Link from "next/link";
-import Head from "next/head";
 import { useRouter } from "next/router";
 import siteConfig from "site.config";
-import TagList from "src/components/TagList";
 import JobDetails from "src/components/JobDetails";
-import { slugify } from "src/slugify";
-import PageMeta from "../PageMeta";
-import { formatDistanceToNow } from "date-fns";
-import { dateFormat } from "src/dateFormat";
+import PageMeta from "src/components/PageMeta";
+import JobSubtitle from "src/components/JobSubtitle";
 
 type Props = {
   frontMatter: any;
@@ -17,7 +12,7 @@ type Props = {
 
 export default function JobTemplate({ frontMatter: post, children }: Props) {
   const router = useRouter();
-  let editUrl = `${siteConfig.githubUrl}edit/master/src/pages${router.pathname}/index.mdx`
+  let editUrl = `${siteConfig.githubUrl}edit/master/src/pages${router.pathname}/index.mdx`;
 
   return (
     <Layout>
@@ -30,31 +25,11 @@ export default function JobTemplate({ frontMatter: post, children }: Props) {
       <article className="article mt-8 lg:max-w-3xl mr-auto ml-auto">
         <header className="inset mb-12">
           <h1 className="hashtag mb-4 text-4xl md:text-5xl font-bold leading-tight">
-            {post.title}
+            {post.title}&nbsp;
+            <JobSubtitle job={post} />
           </h1>
 
           <JobDetails job={post} />
-
-          <ul className="mt-2 text-foreground-secondary text-sm">
-            {post.company &&
-              <li>
-                <label className="font-bold">With:&nbsp;</label>
-                {post.company}
-              </li>
-            }
-            {post.location &&
-              <li>
-                <label className="font-bold">Location:&nbsp;</label>
-                {post.location}
-              </li>
-            }
-            {post.seniority &&
-              <li>
-                <label className="font-bold">Seniority:&nbsp;</label>
-                {post.seniority}
-              </li>
-            }
-          </ul>
 
           {post.apply &&
             <a

--- a/src/pages/jobs/2020-07-31-test-job/index.mdx
+++ b/src/pages/jobs/2020-07-31-test-job/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: job
-title: 'Frontend Developer Role at Example Studios'
+title: 'Example Frontend Developer Role at Example Studios'
 date: '2020-09-13T08:00:00Z'
 expiryDate: '2020-12-12T00:00:00Z'
 role: Frontend Developer
@@ -11,6 +11,4 @@ seniority: Mid
 apply: mailto:info@norfolkdevelopers.com?subject=Apply for Frontend Dev Role at Example Studios
 ---
 
-## An Example Frontend Developer Role on the new Norfolk Developers Jobs Board
-
-This content area can contain your job specification.
+We're looking for a **whirlwind**, **amazing**, **entrepreneurial** graduate front-end developer with 37 years experience in React and front-end development. In return, you'll be offered a market leading salary and an office with great perks such as a desk and a chair. 

--- a/src/pages/jobs/2020-07-31-test-job/index.mdx
+++ b/src/pages/jobs/2020-07-31-test-job/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: job
-title: 'Example Frontend Developer Role at Example Studios'
+title: 'Frontend Developer Role at Example Studios'
 date: '2020-09-13T08:00:00Z'
 expiryDate: '2020-12-12T00:00:00Z'
 role: Frontend Developer
@@ -11,4 +11,6 @@ seniority: Mid
 apply: mailto:info@norfolkdevelopers.com?subject=Apply for Frontend Dev Role at Example Studios
 ---
 
-We're looking for a **whirlwind**, **amazing**, **entrepreneurial** graduate front-end developer with 37 years experience in React and front-end development. In return, you'll be offered a market leading salary and an office with great perks such as a desk and a chair. 
+## An Example Frontend Developer Role on the new Norfolk Developers Jobs Board
+
+This content area can contain your job specification.


### PR DESCRIPTION
This commit updates the presentation of job meta information such as salary, location and seniority. The idea behind this being that too much information in the emoji detail row essentially renders it useless and that salary, location and seniority information is much more important to people than when the job was originally posted.

I also removed salary information from the emoji bar as it doesn't make sense to me to have it in two locations. 

New job list page (subtitle isn't highlighted as it's not an anchor and is supplementary information).

![image](https://user-images.githubusercontent.com/47109131/93708432-13f34980-fb2e-11ea-843b-16dd631138c8.png)

New job detail page:

![image](https://user-images.githubusercontent.com/47109131/93708449-2cfbfa80-fb2e-11ea-9418-5d2c2f074260.png)

I've checked that everything functions correctly on both pages without any location/salary/seniority information, however not having location info and salary/seniority may result in there being a rogue slash. I'm assuming, @Illizian, that all three fields are essentially a requirement and will be looked at as a result of any job PR, or should I actually account for some of these not being present? 

