### PR TITLE
Add date to post template

### DIFF
--- a/src/components/PostDate.tsx
+++ b/src/components/PostDate.tsx
@@ -1,0 +1,16 @@
+import { differenceInCalendarDays, formatDistance } from "date-fns";
+import { dateFormat } from "src/dateFormat";
+
+export interface PostDateProps {
+  date: Date;
+}
+
+export default function PostDate({ date }: PostDateProps) {
+  const daysSincePosted = differenceInCalendarDays(new Date(), date);
+
+  if (daysSincePosted > 7) {
+    return <>on {dateFormat(date)}</>
+  }
+
+  return <span title={dateFormat(date)}>{formatDistance(date, new Date())} ago</span>
+}

--- a/src/components/layout/PostTemplate.tsx
+++ b/src/components/layout/PostTemplate.tsx
@@ -1,6 +1,5 @@
 import Layout from "./Layout";
 import Link from "next/link";
-import Head from "next/head";
 import { useRouter } from "next/router";
 import siteConfig from "site.config";
 import TagList from "src/components/TagList";

--- a/src/components/layout/PostTemplate.tsx
+++ b/src/components/layout/PostTemplate.tsx
@@ -7,6 +7,7 @@ import TagList from "src/components/TagList";
 import { slugify } from "src/slugify";
 import PageMeta from "../PageMeta";
 import { dateFormat } from "src/dateFormat";
+import { Fragment } from "react";
 
 type Props = {
   frontMatter: any;
@@ -36,7 +37,7 @@ export default function PostTemplate({ frontMatter: post, children }: Props) {
             <span className="block text-base text-gray-600">
               by{" "}
               {post.author.map((author: string, i: number) => (
-                <span key={author}>
+                <Fragment key={author}>
                   <Link
                     href="/author/[authorSlug]"
                     as={`/author/${slugify(author)}`}
@@ -44,7 +45,7 @@ export default function PostTemplate({ frontMatter: post, children }: Props) {
                     <a className="underline">{author}</a>
                   </Link>
                   {i < post.author.length - 1 ? ", " : ""}
-                </span>
+                </Fragment>
               ))}
               {post.date && ` on ${dateFormat(new Date(post.date))}`}
             </span>

--- a/src/components/layout/PostTemplate.tsx
+++ b/src/components/layout/PostTemplate.tsx
@@ -71,7 +71,7 @@ interface PostDateProps {
 function PostDate({ date }: PostDateProps) {
   const daysSincePosted = differenceInCalendarDays(new Date(), date);
 
-  if (daysSincePosted > 7 || !Intl.RelativeTimeFormat) {
+  if (daysSincePosted > 7) {
     return <>on {dateFormat(date)}</>
   }
 

--- a/src/components/layout/PostTemplate.tsx
+++ b/src/components/layout/PostTemplate.tsx
@@ -6,6 +6,7 @@ import siteConfig from "site.config";
 import TagList from "src/components/TagList";
 import { slugify } from "src/slugify";
 import PageMeta from "../PageMeta";
+import { dateFormat } from "src/dateFormat";
 
 type Props = {
   frontMatter: any;
@@ -31,14 +32,9 @@ export default function PostTemplate({ frontMatter: post, children }: Props) {
           <h1 className="hashtag mt-2 mb-1 text-4xl md:text-5xl font-bold leading-tight">
             {post.title}
           </h1>
-          {post.date && (
-            <p className="block text-foreground-secondary font-bold">
-              {/* {dateFormat(new Date(post.date))} */}
-            </p>
-          )}
           {post.author && siteConfig.features.authorPages ? (
             <span className="block text-base text-gray-600">
-              by{[" "]}
+              by{" "}
               {post.author.map((author: string, i: number) => (
                 <span key={author}>
                   <Link
@@ -50,6 +46,7 @@ export default function PostTemplate({ frontMatter: post, children }: Props) {
                   {i < post.author.length - 1 ? ", " : ""}
                 </span>
               ))}
+              {post.date && ` on ${dateFormat(new Date(post.date))}`}
             </span>
           ) : null}
           {post.hero && <img className="mt-12 mb-12" src={post.hero} />}

--- a/src/components/layout/PostTemplate.tsx
+++ b/src/components/layout/PostTemplate.tsx
@@ -6,9 +6,13 @@ import siteConfig from "site.config";
 import TagList from "src/components/TagList";
 import { slugify } from "src/slugify";
 import PageMeta from "../PageMeta";
-import { dateFormat } from "src/dateFormat";
 import { Fragment } from "react";
-import { differenceInCalendarDays, formatDistance } from "date-fns";
+import dynamic from "next/dynamic";
+
+// Lazy load the PostDate component so that relative times show relative to the user's TZ
+const PostDate = dynamic(() => import('../PostDate'), {
+  ssr: false
+});
 
 type Props = {
   frontMatter: any;
@@ -62,18 +66,4 @@ export default function PostTemplate({ frontMatter: post, children }: Props) {
       </article>
     </Layout>
   );
-}
-
-interface PostDateProps {
-  date: Date;
-}
-
-function PostDate({ date }: PostDateProps) {
-  const daysSincePosted = differenceInCalendarDays(new Date(), date);
-
-  if (daysSincePosted > 7) {
-    return <>on {dateFormat(date)}</>
-  }
-
-  return <span title={dateFormat(date)}>{formatDistance(date, new Date())} ago</span>
 }

--- a/src/components/layout/PostTemplate.tsx
+++ b/src/components/layout/PostTemplate.tsx
@@ -8,6 +8,7 @@ import { slugify } from "src/slugify";
 import PageMeta from "../PageMeta";
 import { dateFormat } from "src/dateFormat";
 import { Fragment } from "react";
+import { differenceInCalendarDays, formatDistance } from "date-fns";
 
 type Props = {
   frontMatter: any;
@@ -47,7 +48,7 @@ export default function PostTemplate({ frontMatter: post, children }: Props) {
                   {i < post.author.length - 1 ? ", " : ""}
                 </Fragment>
               ))}
-              {post.date && ` on ${dateFormat(new Date(post.date))}`}
+              {post.date && <>{' '}<PostDate date={new Date(post.date)} /></>}
             </span>
           ) : null}
           {post.hero && <img className="mt-12 mb-12" src={post.hero} />}
@@ -61,4 +62,18 @@ export default function PostTemplate({ frontMatter: post, children }: Props) {
       </article>
     </Layout>
   );
+}
+
+interface PostDateProps {
+  date: Date;
+}
+
+function PostDate({ date }: PostDateProps) {
+  const daysSincePosted = differenceInCalendarDays(new Date(), date);
+
+  if (daysSincePosted > 7 || !Intl.RelativeTimeFormat) {
+    return <>on {dateFormat(date)}</>
+  }
+
+  return <span title={dateFormat(date)}>{formatDistance(date, new Date())} ago</span>
 }


### PR DESCRIPTION
If the post was created less than a week ago, show a relative date string eg. "about 5 hours ago". You can hover over this to view the exact date.

Otherwise, just show the publish date.