### PR TITLE
Remove dark mode flicker in (almost) all situations

### DIFF
--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -5,7 +5,7 @@ import useDarkMode from "use-dark-mode";
  */
 export default function DarkModeToggle() {
   const darkMode = useDarkMode(
-    // @ts-ignore
+    // @ts-ignore use-dark-mode is passing this value directly to useState, so the types are actually wrong here it should accept a lazy initial state
     getPrefersDarkMode
   );
 

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,0 +1,35 @@
+import useDarkMode from "use-dark-mode";
+
+/**
+ * This component should only be called on the client as it accesses window in it's body
+ */
+export default function DarkModeToggle() {
+  const darkMode = useDarkMode(
+    // @ts-ignore
+    getPrefersDarkMode
+  );
+
+  return (
+    <button
+      onClick={() => darkMode.toggle()}
+      id="toggleTheme"
+      aria-pressed={darkMode.value}
+      className="order-2 lg:order-3 ml-auto p-2 inline-block transform hover:-rotate-180 duration-300 ease-in-out "
+    >
+      {darkMode.value ? (
+        <span role="img" aria-label="sun">
+          ☀️
+        </span>
+      ) : (
+        <span role="img" aria-label="sunglasses face">
+          😎
+        </span>
+      )}
+    </button>
+  );
+}
+
+
+function getPrefersDarkMode(): boolean {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -4,6 +4,7 @@ import config from "../../../site.config";
 import { useRouter } from "next/router";
 import Logo from "../Logo";
 import PageMeta from "../PageMeta";
+import { useEffect, useState } from "react";
 
 const DarkModeToggle = dynamic(() => import('../DarkModeToggle'), {
   ssr: false
@@ -24,13 +25,21 @@ type Props = {
 
 export default function Layout({ children, location }: Props) {
   const router = useRouter();
+  const [transitionDurationClass, setTransitionDurationClass] = useState('');
+
+  useEffect(() => {
+    // This little maneuver ~~is gonna~~ cost us 51 years...
+    // Chrome seems to apply a transition on the background sometimes on initial load from white (no content) -> dark when in darkmode.
+    // Applying the duration style only on the client side render fixes it.
+    setTransitionDurationClass('duration-1000');
+  }, []);
 
   return (
     <>
       <PageMeta />
 
       <div
-        className={`text-foreground-primary px-8 bg-background-primary duration-200 border-t-0 border-red-500`}
+        className={`text-foreground-primary px-8 bg-background-primary ${transitionDurationClass} border-t-0 border-red-500`}
       >
         <div className="flex flex-col min-h-screen ml-auto mr-auto w-full md:w-4/5 lg:max-w-3xl">
           <header className="mt-6 md:mb-3 flex flex-wrap fade-out">

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,10 +1,13 @@
 import Link from "next/link";
+import dynamic from 'next/dynamic'
 import config from "../../../site.config";
-import siteConfig from "../../../site.config";
-import useDarkMode from "use-dark-mode";
 import { useRouter } from "next/router";
 import Logo from "../Logo";
 import PageMeta from "../PageMeta";
+
+const DarkModeToggle = dynamic(() => import('../DarkModeToggle'), {
+  ssr: false
+});
 
 const navLinks = [
   { url: `/${config.postsDirectory}`, label: "posts" },
@@ -20,7 +23,6 @@ type Props = {
 };
 
 export default function Layout({ children, location }: Props) {
-  const darkMode = useDarkMode(false);
   const router = useRouter();
 
   return (
@@ -58,22 +60,7 @@ export default function Layout({ children, location }: Props) {
                 </Link>
               ))}
             </nav>
-            <button
-              onClick={() => darkMode.toggle()}
-              id="toggleTheme"
-              aria-pressed={darkMode.value}
-              className="order-2 lg:order-3 ml-auto p-2 inline-block transform hover:-rotate-180 duration-300 ease-in-out "
-            >
-              {darkMode.value ? (
-                <span role="img" aria-label="sun">
-                  ☀️
-                </span>
-              ) : (
-                <span role="img" aria-label="sunglasses face">
-                  😎
-                </span>
-              )}
-            </button>
+            <DarkModeToggle />
           </header>
           <main className="flex-grow">{children}</main>
           <footer className="my-6 border-border-primary py-4 text-base text-foreground-secondary text-center">

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -48,6 +48,42 @@ path.logo-nor {
 }
 
 @media (prefers-color-scheme: dark) {
+  body {
+    --color-bg-primary: theme("colors.gray.900");
+    --color-bg-secondary: theme("colors.gray.800");
+    --color-text-primary: theme("colors.gray.300");
+    --color-text-secondary: theme("colors.gray.500");
+    --color-text-tertiary: theme("colors.gray.600");
+    --color-border-primary: theme("colors.gray.700");
+    --color-href-base: theme("colors.red.700");
+    --color-href-hover: theme("colors.red.300");
+    --color-href-active: theme("colors.red.400");
+  }
+
+  path.logo-nor {
+    fill: theme("colors.gray.200");
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  body {
+    --color-bg-primary: theme("colors.gray.100");
+    --color-bg-secondary: theme("colors.gray.200");
+    --color-text-primary: theme("colors.gray.900");
+    --color-text-secondary: theme("colors.gray.600");
+    --color-text-tertiary: theme("colors.gray.500");
+    --color-border-primary: theme("colors.gray.300");
+    --color-href-base: theme("colors.red.400");
+    --color-href-hover: theme("colors.red.800");
+    --color-href-active: theme("colors.red.700");
+  }
+
+  path.logo-nor {
+    fill: theme("colors.gray.800");
+  }
+}
+
+@media (prefers-color-scheme: dark) {
   html {
     content: "dark";
   }


### PR DESCRIPTION
Fixes #74

This fix solves this problem in all situations unless:

- You have selected light mode but your OS is set to dark mode (or vice versa) - maybe this could be solved by storing the preference in a cookie and SSRing

or

- Your browser does not support the `prefers-color-scheme` media query and you have toggled to dark mode in a previous session/tab - this could be solved by not rendering on the server in these browsers I guess 😬