### PR TITLE
Fix bug allowing past events to display as "Today"

### DIFF
--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -1,7 +1,7 @@
-import useSWR from "swr";
-import { fetcher } from "src/fetcher";
 import { differenceInDays, format } from "date-fns";
 import siteConfig from "site.config";
+import { fetcher } from "src/fetcher";
+import useSWR from "swr";
 
 type Props = {
   endpoint: string; // endpoint to call for event info
@@ -12,8 +12,8 @@ const meetupAPIEndpoint = `${siteConfig.meetupSrc}?limit=${siteConfig.meetupEven
 
 export default function EventsList({ initialData, endpoint }: Props) {
   const { data, error } = useSWR<MeetupEvent[]>(meetupAPIEndpoint, fetcher, {
-    initialData,
-  });
+      initialData,
+      });
 
   if (error)
     return (
@@ -40,70 +40,74 @@ export default function EventsList({ initialData, endpoint }: Props) {
 
   return (
     <ul className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      {data.slice(0, 9).map((event) => {
-        const currentDate = new Date();
-        const dateOfEvent = new Date(event.time);
-        const dateDifference = differenceInDays(dateOfEvent, currentDate);
+      {
+         data.filter((event ) => event.status === "upcoming")
+        .slice(0, 9)
+      
+      .map((event ) => {
+          const currentDate = new Date();
+          const dateOfEvent = new Date(event.time);
+          const dateDifference = differenceInDays(dateOfEvent, currentDate);
 
-        let formattedDateOfEvent;
-
+          let formattedDateOfEvent;
+          
         if (dateDifference < 1) {
-          formattedDateOfEvent = `Today, ${format(
+            formattedDateOfEvent = `Today, ${format(
             new Date(event.time),
             "do LLL "
-          )}`;
+            )}`;
         } else if (dateDifference < 2) {
-          formattedDateOfEvent = `Tomorrow, ${format(
+            formattedDateOfEvent = `Tomorrow, ${format(
             new Date(event.time),
-            "do LLL"
-          )}`;
+              "do LLL"
+            )}`;
         } else if (dateDifference < 7) {
-          formattedDateOfEvent = `This ${format(
+            formattedDateOfEvent = `This ${format(
             new Date(event.time),
-            "eeee, do LLL"
-          )}`;
+              "eeee, do LLL"
+            )}`;
         } else if (dateDifference < 14) {
-          formattedDateOfEvent = `Next ${format(
+            formattedDateOfEvent = `Next ${format(
             new Date(event.time),
             "eeee, do LLL "
-          )}`;
-        } else {
-          formattedDateOfEvent = format(
+            )}`;
+          } else {
+            formattedDateOfEvent = format(
             new Date(event.time),
-            "eeee, do LLL yyyy"
-          );
-        }
+              "eeee, do LLL yyyy"
+            );
+          }
 
-        return (
-          <li
-            key={event.id}
-            className="block bg-background-secondary rounded leading-tight tracking-tight"
-          >
-            <a href={event.link} className="p-4 block hover:outline">
-              <h3 className="font-bold text-lg">
-                <span role="img" aria-label="calendar">
-                  📆
-                </span>
-                &nbsp;{event.name}
-              </h3>
-              <p className="text-foreground-secondary mt-2 font-bold">
-                {formattedDateOfEvent}
-              </p>
-              <p className="mt-1 text-foreground-secondary">
-                {format(new Date(event.time), "HH:mm")} to{" "}
-                {format(new Date(event.time + event.duration), "HH:mm")}
-              </p>
-              <p className="text-href-base mt-1 font-bold">RSVP &raquo;</p>
-              <p className="text-sm mt-1 text-foreground-tertiary">
-                {event.yes_rsvp_count}
-                {event.rsvp_limit
-                  ? ` / ${event.rsvp_limit}`
-                  : null} attending{" "}
-              </p>
-            </a>
-          </li>
-        );
-      })}
+          return (
+            <li
+              key={event.id}
+              className="block bg-background-secondary rounded leading-tight tracking-tight"
+            >
+              <a href={event.link} className="p-4 block hover:outline">
+                <h3 className="font-bold text-lg">
+                  <span role="img" aria-label="calendar">
+                    📆
+                  </span>
+                  &nbsp;{event.name}
+                </h3>
+                <p className="text-foreground-secondary mt-2 font-bold">
+                  {formattedDateOfEvent}
+                </p>
+                <p className="mt-1 text-foreground-secondary">
+                  {format(new Date(event.time), "HH:mm")} to{" "}
+                  {format(new Date(event.time + event.duration), "HH:mm")}
+                </p>
+                <p className="text-href-base mt-1 font-bold">RSVP &raquo;</p>
+                <p className="text-sm mt-1 text-foreground-tertiary">
+                  {event.yes_rsvp_count}
+                  {event.rsvp_limit
+                    ? ` / ${event.rsvp_limit}`
+                    : null} attending{" "}
+                </p>
+              </a>
+            </li>
+          );
+        })}
     </ul>
   );
 }


### PR DESCRIPTION
Any events returned by the meetup API with a date in the past are currently displaying as "Today"
This filters the returned events to only have the status of "upcoming" to prevent that.

Perhaps a better fix maybe adding a param to the API request, but I'm not sure if that is supported.

This fix is the first time I've worked in whatever language and framework this is. 😆